### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
         "semi": ["error", "always"]
     },
     "parserOptions": {
-        "ecmaVersion": 8,
+        "ecmaVersion": 2020,
         "sourceType": "module"
     },
     "ignorePatterns": [

--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: 'yarn build'
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -26,3 +30,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: "${{ github.event.inputs.script }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: 'yarn build'
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -26,6 +30,7 @@ jobs:
       package_manager: ${{ inputs.package_manager || 'yarn' }}
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{ inputs.script || 'yarn build' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -7,6 +7,10 @@ on:
         description: "Base branch to create the PR against"
         required: true
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: write
@@ -21,3 +25,4 @@ jobs:
       original-owner: "mmoyaferrer"
       repo-name: "set-github-variable"
       base_branch: ${{ inputs.base_branch }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 <div align="center">
   📦
 </div>

--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
         description: Response data
 
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -45912,26 +45912,58 @@ axios.default = axios;
 // this module should only have a default export
 /* harmony default export */ const lib_axios = (axios);
 
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(9896);
 ;// CONCATENATED MODULE: ./src/index.js
 
 
 
 
 
-async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
 
+async function validateSubscription() {
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && external_fs_.existsSync(eventPath)) {
+    const payload = JSON.parse(external_fs_.readFileSync(eventPath, 'utf8'));
+    repoPrivate = payload?.repository?.private;
+  }
+
+  const upstream = 'mmoyaferrer/set-github-variable';
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+
+  core.info('');
+  core.info('[1;36mStepSecurity Maintained Action[0m');
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info('[32m✓ Free for public repositories[0m');
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info('');
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const body = { action: action || '' };
+
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl;
   try {
-    await lib_axios.get(API_URL, { timeout: 3000 });
+    await lib_axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
+    if (lib_axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        '[1;31mThis action requires a StepSecurity subscription for private repositories.[0m',
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info('Timeout or API not reachable. Continuing to next step.');
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,51 @@ import core, { getInput, setOutput, setFailed } from '@actions/core';
 import { Octokit } from '@octokit/core';
 import fetch from 'node-fetch';
 import axios from 'axios';
+import fs from 'fs';
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = 'mmoyaferrer/set-github-variable';
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+
+  core.info('');
+  core.info('[1;36mStepSecurity Maintained Action[0m');
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info('[32m✓ Free for public repositories[0m');
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info('');
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+  const body = { action: action || '' };
+
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, { timeout: 3000 });
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        '[1;31mThis action requires a StepSecurity subscription for private repositories.[0m',
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
       );
       process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
     }
+    core.info('Timeout or API not reachable. Continuing to next step.');
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24
- Updated workflow files with configurable node_version input

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- Bumped eslint ecmaVersion to 2020 to support optional chaining

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z